### PR TITLE
Chunk up requests

### DIFF
--- a/timestream.go
+++ b/timestream.go
@@ -166,12 +166,12 @@ func (t TimeStreamAdapter) toRecords(writeRequest *prompb.WriteRequest) (records
 	return
 }
 
-func (t TimeStreamAdapter) splitRecords(records []*timestreamwrite.Record) [][]*timestreamwrite.Record{
+func (t TimeStreamAdapter) splitRecords(records []*timestreamwrite.Record) [][]*timestreamwrite.Record {
 	var chunked [][]*timestreamwrite.Record
 
-	for i := 0; i < len(records); i+= TimestreamMaxRecordsPerRequest {
+	for i := 0; i < len(records); i += TimestreamMaxRecordsPerRequest {
 		end := i + TimestreamMaxRecordsPerRequest
-		if end > len(records){
+		if end > len(records) {
 			end = len(records)
 		}
 


### PR DESCRIPTION
Hi,

I've been experimenting with Timestream with a prometheus remote-write. I found yesterday that timestream will reject your request if you have > 100 records in a single request. The error you get back looks like so:

```
"ValidationException: 1 validation error detected: Value
... all your records you're attempting to send ...
at 'records' failed to satisfy constraint: Member must have length less than or equal to 100"
```

Running the code with this diff allows them to be ingested as expected.