### PR TITLE
Add DescribeEndpoints IAM policy to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ The [Session](https://pkg.go.dev/github.com/aws/aws-sdk-go/aws/session) will att
             "Resource": "arn:aws:timestream:region:AccoundId:database/DatabaseName/table/TableName"
         },
         {
+            "Sid": "AllowDescribeEndpoints",
+            "Effect": "Allow",
+            "Action": "timestream:DescribeEndpoints",
+            "Resource": "*"
+        },
+        {
             "Sid": "AllowValueRead",
             "Effect": "Allow",
             "Action": "timestream:SelectValues",


### PR DESCRIPTION
Hi, 
Installing the adapter I see this log error:

May 11 13:48:09 ip-XXXXXXXXXXX.eu-central-1.compute.internal prometheus-timestream-adapter[18980]: {"level":"warn","ts":1620740889.4611926,"caller":"prometheus-timestream-adapter/timestream.go:134","msg":"Error sending samples to remote storage","err":"AccessDeniedException: User: arn:aws:iam::XXXXXXXXX:user/prometheus-adapter is not authorized to perform: timestream:DescribeEndpoints","storage":"prometheus-timestream-adapter","num_samples":8}

That's why i'm creating this pull request with the fix.

Thank you for the timestream adapter.
