### PR TITLE
Use QueryPages

### DIFF
--- a/timestream.go
+++ b/timestream.go
@@ -234,7 +234,7 @@ func (t TimeStreamAdapter) runReadRequestQuery(q *prompb.Query) (result prompb.Q
 			QueryString: &task.query,
 		},
 		func(output *timestreamquery.QueryOutput, lastPage bool) (continueIterating bool) {
-			continueIterating = true
+			continueIterating = !lastPage
 			timeSeries, innerErr = t.handleQueryResult(output, timeSeries, task.measureName)
 			return
 		},

--- a/timestream.go
+++ b/timestream.go
@@ -233,10 +233,9 @@ func (t TimeStreamAdapter) runReadRequestQuery(q *prompb.Query) (result prompb.Q
 		&timestreamquery.QueryInput{
 			QueryString: &task.query,
 		},
-		func(output *timestreamquery.QueryOutput, lastPage bool) (continueIterating bool) {
-			continueIterating = !lastPage
+		func(output *timestreamquery.QueryOutput, lastPage bool) bool {
 			timeSeries, innerErr = t.handleQueryResult(output, timeSeries, task.measureName)
-			return
+			return !lastPage
 		},
 	)
 

--- a/timestream.go
+++ b/timestream.go
@@ -140,7 +140,7 @@ func (t TimeStreamAdapter) Write(req *prompb.WriteRequest) (err error) {
 	return
 }
 
-func allCharactersValid(str string) bool {
+func (t TimeStreamAdapter) allCharactersValid(str string) bool {
 	isValid := func(char rune) bool {
 		return (char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') ||
 			char == '_' || char == '-' || char == '.'
@@ -163,7 +163,7 @@ func (t TimeStreamAdapter) toRecords(writeRequest *prompb.WriteRequest) (records
 			case len(task.measureName) >= 62:
 				t.logger.Warnw("Measure name exceeds the maximum supported length", "Measure name", task.measureName, "Length", len(task.measureName))
 				continue
-			case !allCharactersValid(task.measureName):
+			case !t.allCharactersValid(task.measureName):
 				t.logger.Warnw("Measure name contains illegal characters", "Measure name", task.measureName)
 				continue
 			}


### PR DESCRIPTION
Hi,

I hope you accept PRs that come out of the blue like this.

I have been using the Timestream adapter and noticed that it does not support paging when reading large queries, so I added that.

This PR also adds a diagnostic message if a measure contains illegal characters, which is something I had problems with and it took me a while to understand what was going on.

Thanks,
Tobias Linton
